### PR TITLE
friendly_name support

### DIFF
--- a/custom_components/nordpool/config_flow.py
+++ b/custom_components/nordpool/config_flow.py
@@ -50,6 +50,7 @@ class NordpoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         data_schema = {
             vol.Required("region", default=None): vol.In(regions),
+            vol.Optional("friendly_name", default=""): str,
             vol.Optional("currency", default=""): vol.In(currencys),
             vol.Optional("VAT", default=True): bool,
             vol.Optional("precision", default=3): vol.Coerce(int),

--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -52,6 +52,18 @@ _REGIONS = {
 # Needed incase a user wants the prices in non local currency
 _CURRENCY_TO_LOCAL = {"DKK": "Kr", "NOK": "Kr", "SEK": "Kr", "EUR": "€"}
 _CURRENTY_TO_CENTS = {"DKK": "Øre", "NOK": "Øre", "SEK": "Öre", "EUR": "c"}
+_SPECIAL_CHAR_AMP = {
+    ord('ä'):'a',
+    ord('ö'):'o',
+    ord('å'):'a',
+    ord('ø'):'o',
+    ord('ü'):'u',
+    ord('ß'):'ss',
+    ord('€'):'e',
+    ord(' '):'_',
+    ord('.'):'',
+    ord(','):'',
+}
 
 DEFAULT_CURRENCY = "NOK"
 DEFAULT_REGION = "Kr.sand"
@@ -137,8 +149,7 @@ class NordpoolSensor(Entity):
         ad_template,
         hass,
     ) -> None:
-        # friendly_name is ignored as it never worked.
-        # rename the sensor in the ui if you dont like the name.
+        self._friendly_name = friendly_name
         self._area = area
         self._currency = currency or _REGIONS[area][0]
         self._price_type = price_type
@@ -196,6 +207,10 @@ class NordpoolSensor(Entity):
         return False
 
     @property
+    def friendly_name(self) -> str:
+        return self._friendly_name
+
+    @property
     def icon(self) -> str:
         return "mdi:flash"
 
@@ -214,15 +229,20 @@ class NordpoolSensor(Entity):
 
     @property
     def unique_id(self):
-        name = "nordpool_%s_%s_%s_%s_%s_%s" % (
-            self._price_type,
-            self._area,
-            self._currency,
-            self._precision,
-            self._low_price_cutoff,
-            self._vat,
-        )
-        name = name.lower().replace(".", "")
+        if self._friendly_name:
+            name = self._friendly_name.lower()
+            name = name.translate(_SPECIAL_CHAR_AMP)
+        else:
+	        name = "nordpool_%s_%s_%s_%s_%s_%s" % (
+	            self._price_type,
+	            self._area,
+	            self._currency,
+	            self._precision,
+	            self._low_price_cutoff,
+	            self._vat,
+	        )
+	        name = name.lower().replace(".", "")
+
         return name
 
     @property

--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -199,7 +199,11 @@ class NordpoolSensor(Entity):
 
     @property
     def name(self) -> str:
-        return self.unique_id
+        if self._friendly_name:
+            name = self._friendly_name
+        else:
+            name = self.unique_id
+        return name
 
     @property
     def should_poll(self):
@@ -230,20 +234,19 @@ class NordpoolSensor(Entity):
     @property
     def unique_id(self):
         if self._friendly_name:
-            name = self._friendly_name.lower()
-            name = name.translate(_SPECIAL_CHAR_AMP)
+            unique_id = self._friendly_name.lower()
+            unique_id = unique_id.translate(_SPECIAL_CHAR_AMP)
         else:
-	        name = "nordpool_%s_%s_%s_%s_%s_%s" % (
+            unique_id = "nordpool_%s_%s_%s_%s_%s_%s" % (
 	            self._price_type,
 	            self._area,
 	            self._currency,
 	            self._precision,
 	            self._low_price_cutoff,
 	            self._vat,
-	        )
-	        name = name.lower().replace(".", "")
-
-        return name
+            )
+            unique_id = unique_id.translate(_SPECIAL_CHAR_AMP)
+        return unique_id
 
     @property
     def device_info(self):

--- a/custom_components/nordpool/translations/en.json
+++ b/custom_components/nordpool/translations/en.json
@@ -7,6 +7,7 @@
                 "description": "Setup a Nordpool sensor",
                 "data": {
                     "region": "Region",
+                    "friendly_name": "friendly_name",
                     "currency": "NOK",
                     "VAT": "Include VAT",
                     "precision": "How many decimals to show",


### PR DESCRIPTION
Fix that supports friendly_name and created pull request. For some reason after reboot second sensor may not start outputting correct values instantly, until that it works it just shows error "Entity is non-numeric: sensor.XXX". But eventually it works and this fix allows to add several nordpool sensors.