### PR TITLE
Renamed "off peak <num>" to "off_peak_<num>"

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -375,8 +375,8 @@ class NordpoolSensor(Entity):
         return {
             "current_price": self.current_price,
             "average": self._average,
-            "off peak 1": self._off_peak_1,
-            "off peak 2": self._off_peak_2,
+            "off_peak_1": self._off_peak_1,
+            "off_peak_2": self._off_peak_2,
             "peak": self._peak,
             "min": self._min,
             "max": self._max,


### PR DESCRIPTION
Renamed attributes "off peak num" to "off_peak_num" to be able to use the attributes easier in templates and to match the naming of current_price which uses underscore instead of whitespace.

Example: {{ states.sensor.nordpool_kwh_se3_sek_3_10_025.attributes.off_peak_2 }}

Also, at the moment *with* whitespaces I can't read the values from InfluxDB to Grafana. But this fix would solve that issue.