### PR TITLE
Add high_price_cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ sensor:
     # low_price = hour_price < average * low_price_cutoff
     low_price_cutoff: 0.95
 
+    # Helper so you can set your "high" price
+    # high_price = hour_price > average * high_price_cutoff
+    high_price_cutoff: 1.05
+
     # What power regions your are interested in.
     # Possible values: "DK1", "DK2", "FI", "LT", "LV", "Oslo", "Kr.sand", "Bergen", "Molde", "Tr.heim", "Tromsø", "SE1", "SE2", "SE3","SE4", "SYS", "EE"
     region: "Kr.sand"

--- a/custom_components/nordpool/config_flow.py
+++ b/custom_components/nordpool/config_flow.py
@@ -54,6 +54,7 @@ class NordpoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Optional("VAT", default=True): bool,
             vol.Optional("precision", default=3): vol.Coerce(int),
             vol.Optional("low_price_cutoff", default=1.0): vol.Coerce(float),
+            vol.Optional("high_price_cutoff", default=1.0): vol.Coerce(float),
             vol.Optional("price_in_cents", default=False): bool,
             vol.Optional("price_type", default="kWh"): vol.In(price_types),
             vol.Optional("additional_costs", default=""): str,

--- a/custom_components/nordpool/translations/en.json
+++ b/custom_components/nordpool/translations/en.json
@@ -11,6 +11,7 @@
                     "VAT": "Include VAT",
                     "precision": "How many decimals to show",
                     "low_price_cutoff": "low price cut off",
+                    "high_price_cutoff": "high price cut off",
                     "price_in_cents": "Price in Cents",
                     "price_type": "Price in format",
                     "additional_costs": "Template for additional costs"

--- a/custom_components/nordpool/translations/et.json
+++ b/custom_components/nordpool/translations/et.json
@@ -12,6 +12,7 @@
                     "VAT": "Koos käibemaksuga",
                     "precision": "Mitu kohta peale koma",
                     "low_price_cutoff": "Madala hinna tase",
+                    "high_price_cutoff": "Kõrge hinna tase",
                     "price_in_cents": "Hind sentides",
                     "price_type": "Hinna vorming",
                     "additional_costs": "Lisanduvate hindade mall"

--- a/custom_components/nordpool/translations/fi.json
+++ b/custom_components/nordpool/translations/fi.json
@@ -12,6 +12,7 @@
                     "VAT": "Sisällytä ALV",
                     "precision": "Desimaalien lukumäärä",
                     "low_price_cutoff": "Matalan hinnan raja-arvo",
+                    "high_price_cutoff": "Korkea hinnan raja-arvo",
                     "price_in_cents": "Hinta senteissä",
                     "price_type": "Hinnan yksikkö",
                     "additional_costs": "Sivukulujen laskenta Template"

--- a/custom_components/nordpool/translations/nb.json
+++ b/custom_components/nordpool/translations/nb.json
@@ -11,6 +11,7 @@
                     "VAT": "Inkluder MVA",
                     "precision": "Antall desimaler som vises",
                     "low_price_cutoff": "Grense for lav-pris",
+                    "high_price_cutoff": "Grense for høy-pris",
                     "price_in_cents": "Pris i øre",
                     "price_type": "Pris i format",
                     "additional_costs": "Mal for tilleggskostnader"

--- a/custom_components/nordpool/translations/sv.json
+++ b/custom_components/nordpool/translations/sv.json
@@ -12,6 +12,7 @@
                     "VAT": "Inkludera moms",
                     "precision": "Hur många decimaler ska visas",
                     "low_price_cutoff": "Lägsta prisnivå",
+                    "high_price_cutoff": "Högsta prisnivå",
                     "price_in_cents": "Pris i ören",
                     "price_type": "Prisformat",
                     "additional_costs": "Mall för ytterligare kostnader"

--- a/info.md
+++ b/info.md
@@ -33,6 +33,10 @@ sensor:
     # low_price = hour_price < average * low_price_cutoff
     low_price_cutoff: 0.95
 
+    # Helper so you can set your "high" price
+    # high_price = hour_price > average * high_price_cutoff
+    high_price_cutoff: 1.05
+
     # What power regions your are interested in.
     # Possible values: "DK1", "DK2", "FI", "LT", "LV", "Oslo", "Kr.sand", "Bergen", "Molde", "Tr.heim", "Tromsø", "SE1", "SE2", "SE3","SE4", "SYS"
     region: "Kr.sand"


### PR DESCRIPTION
Similar to low_price_cutoff, but checks if price is above average.

Changes the entity_id, so will break backwards compatibility.
Renames "low price" to "low_price", so that it is consistent with the other attributes.