### PR TITLE
Add config entry for custom VAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ sensor:
     VAT: True
     
     # Do you want to use a custom VAT value? Default False
-    # n.b. This custom value is only used if VAT is included
+    # n.b. This custom value is only used if VAT is set to True (see above)
     use_custom_VAT: False
-    # Custom VAT value written as decimal (e.g. 25% is 0.25)
+    # Custom VAT value written as decimal (e.g. 25% VAT is 0.25)
     custom_VAT_value: 0.25
   
     # What currency the api fetches the prices in

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ sensor:
 
     # Should the prices include vat? Default True
     VAT: True
-
+    
+    # Do you want to use a custom VAT value? Default False
+    # n.b. This custom value is only used if VAT is included
+    use_custom_VAT: False
+    # Custom VAT value written as decimal (e.g. 25% is 0.25)
+    custom_VAT_value: 0.25
+  
     # What currency the api fetches the prices in
     # this is only need if you want a sensor in a non local currecy
     currency: "EUR"

--- a/custom_components/nordpool/config_flow.py
+++ b/custom_components/nordpool/config_flow.py
@@ -52,6 +52,8 @@ class NordpoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("region", default=None): vol.In(regions),
             vol.Optional("currency", default=""): vol.In(currencys),
             vol.Optional("VAT", default=True): bool,
+            vol.Optional("use_custom_VAT", default=False): bool,
+            vol.Optional("custom_VAT_value", default=0.25): vol.Coerce(float),
             vol.Optional("precision", default=3): vol.Coerce(int),
             vol.Optional("low_price_cutoff", default=1.0): vol.Coerce(float),
             vol.Optional("price_in_cents", default=False): bool,
@@ -62,6 +64,7 @@ class NordpoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         placeholders = {
             "region": regions,
             "currency": currencys,
+            "custom_VAT_value": "0.25",
             "price_type": price_types,
             "additional_costs": "{{0.0|float}}",
         }

--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -70,6 +70,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         # This is only needed if you want the some area but want the prices in a non local currency
         vol.Optional("currency", default=""): cv.string,
         vol.Optional("VAT", default=True): cv.boolean,
+        vol.Optional("use_custom_VAT", default=False): cv.boolean,
+        vol.Optional("custom_VAT_value", default=0.25): cv.small_float,
         vol.Optional("precision", default=3): cv.positive_int,
         vol.Optional("low_price_cutoff", default=1.0): cv.small_float,
         vol.Optional("price_type", default="kWh"): vol.In(list(_PRICE_IN.keys())),
@@ -90,6 +92,8 @@ def _dry_setup(hass, config, add_devices, discovery_info=None):
     low_price_cutoff = config.get("low_price_cutoff")
     currency = config.get("currency")
     vat = config.get("VAT")
+    use_custom_vat = config.get("use_custom_VAT")
+    custom_vat_value = config.get("custom_VAT_value")
     use_cents = config.get("price_in_cents")
     ad_template = config.get("additional_costs")
     api = hass.data[DOMAIN]
@@ -101,6 +105,8 @@ def _dry_setup(hass, config, add_devices, discovery_info=None):
         low_price_cutoff,
         currency,
         vat,
+        use_custom_vat,
+        custom_vat_value,
         use_cents,
         api,
         ad_template,
@@ -132,6 +138,8 @@ class NordpoolSensor(Entity):
         low_price_cutoff,
         currency,
         vat,
+        use_custom_vat,
+        custom_vat_value,
         use_cents,
         api,
         ad_template,
@@ -150,7 +158,10 @@ class NordpoolSensor(Entity):
         self._hass = hass
 
         if vat is True:
-            self._vat = _REGIONS[area][2]
+            if use_custom_vat is True:
+                self._vat = custom_vat_value
+            else:
+                self._vat = _REGIONS[area][2]
         else:
             self._vat = 0
 

--- a/custom_components/nordpool/translations/en.json
+++ b/custom_components/nordpool/translations/en.json
@@ -9,6 +9,8 @@
                     "region": "Region",
                     "currency": "NOK",
                     "VAT": "Include VAT",
+                    "use_custom_VAT": "Use custom VAT value",
+                    "custom_VAT_value": "Custom VAT value",
                     "precision": "How many decimals to show",
                     "low_price_cutoff": "low price cut off",
                     "price_in_cents": "Price in Cents",

--- a/custom_components/nordpool/translations/et.json
+++ b/custom_components/nordpool/translations/et.json
@@ -10,6 +10,8 @@
                     "friendly_name": "Kuvatav nimi",
                     "currency": "EUR",
                     "VAT": "Koos käibemaksuga",
+                    "use_custom_VAT": "Kasutage kohandatud käibemaksu väärtust",
+                    "custom_VAT_value": "Kohandatud käibemaksu väärtus",
                     "precision": "Mitu kohta peale koma",
                     "low_price_cutoff": "Madala hinna tase",
                     "price_in_cents": "Hind sentides",

--- a/custom_components/nordpool/translations/fi.json
+++ b/custom_components/nordpool/translations/fi.json
@@ -10,6 +10,8 @@
                     "friendly_name": "Nimi käyttöliittymässä",
                     "currency": "EUR",
                     "VAT": "Sisällytä ALV",
+                    "use_custom_VAT": "Käytä mukautettua ALV-arvoa",
+                    "custom_VAT_value": "Muokattu ALV-arvo",
                     "precision": "Desimaalien lukumäärä",
                     "low_price_cutoff": "Matalan hinnan raja-arvo",
                     "price_in_cents": "Hinta senteissä",

--- a/custom_components/nordpool/translations/nb.json
+++ b/custom_components/nordpool/translations/nb.json
@@ -9,6 +9,8 @@
                     "region": "Region",
                     "currency": "NOK",
                     "VAT": "Inkluder MVA",
+                    "use_custom_VAT": "Bruk egendefinert mva-verdi",
+                    "custom_VAT_value": "Egendefinert mva-verdi",
                     "precision": "Antall desimaler som vises",
                     "low_price_cutoff": "Grense for lav-pris",
                     "price_in_cents": "Pris i øre",

--- a/custom_components/nordpool/translations/sv.json
+++ b/custom_components/nordpool/translations/sv.json
@@ -10,6 +10,8 @@
                     "friendly_name": "Visningsnamn",
                     "currency": "SEK",
                     "VAT": "Inkludera moms",
+                    "use_custom_VAT": "Använd anpassat momsvärde",
+                    "custom_VAT_value": "Anpassat momsvärde",
                     "precision": "Hur många decimaler ska visas",
                     "low_price_cutoff": "Lägsta prisnivå",
                     "price_in_cents": "Pris i ören",

--- a/info.md
+++ b/info.md
@@ -24,6 +24,12 @@ sensor:
 
     # Should the prices include vat? Default True
     VAT: True
+    
+    # Do you want to use a custom VAT value? Default False
+    # n.b. This custom value is only used if VAT is included
+    use_custom_VAT: False
+    # Custom VAT value written as decimal (e.g. 25% is 0.25)
+    custom_VAT_value: 0.25
 
     # What currency the api fetches the prices in
     # this is only need if you want a sensor in a non local currecy

--- a/info.md
+++ b/info.md
@@ -26,9 +26,9 @@ sensor:
     VAT: True
     
     # Do you want to use a custom VAT value? Default False
-    # n.b. This custom value is only used if VAT is included
+    # n.b. This custom value is only used if VAT is set to True (see above)
     use_custom_VAT: False
-    # Custom VAT value written as decimal (e.g. 25% is 0.25)
+    # Custom VAT value written as decimal (e.g. 25% VAT is 0.25)
     custom_VAT_value: 0.25
 
     # What currency the api fetches the prices in


### PR DESCRIPTION
Added a config entry to overwrite the hardcoded VAT values. As discussed in #163, this would be a better solution than just temporarily changing the value. This way all users have a way to easily change VAT values if their situation calls for that, without changing the code.

Also added UI translations for other languages than English, but I don't know if they are any good since I got them from Google Translate.