### PR TITLE
No VAT for North Noray

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -33,7 +33,7 @@ _REGIONS = {
     "Bergen": ["NOK", "Norway", 0.25],
     "Molde": ["NOK", "Norway", 0.25],
     "Tr.heim": ["NOK", "Norway", 0.25],
-    "Tromsø": ["NOK", "Norway", 0.25],
+    "Tromsø": ["NOK", "Norway", 0.0],
     "SE1": ["SEK", "Sweden", 0.25],
     "SE2": ["SEK", "Sweden", 0.25],
     "SE3": ["SEK", "Sweden", 0.25],


### PR DESCRIPTION
> Elektrisk kraft mv. er imidlertid fritatt for merverdiavgift når omsetningen skjer til husstander i Nord-Norge.
[kilde](https://www.regjeringen.no/no/dokumenter/nou-2019-11/id2645213/?ch=10)