### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -41,7 +41,7 @@ _REGIONS = {
     # What zone is this?
     "SYS": ["EUR", "System zone", 0.25],
     "FR": ["EUR", "France", 0.055],
-    "NL": ["EUR", "Netherlands", 0.21],
+    "NL": ["EUR", "Netherlands", 0.09],
     "BE": ["EUR", "Belgium", 0.21],
     "AT": ["EUR", "Austria", 0.20],
     # Tax is disabled for now, i need to split the areas


### PR DESCRIPTION
As of July 1st, Energy VAT in the Netherlands changed from 21% to 9%.
Sources: 
https://business.gov.nl/amendment/vat-on-energy-lowered/ 
https://www.iamexpat.nl/expat-info/dutch-expat-news/dutch-government-confirms-dates-petrol-tax-cuts-energy-vat-cap