### PR TITLE
Fix regression with decimal precision.

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -323,7 +323,7 @@ class NordpoolSensor(SensorEntity):
         if self._use_cents:
             price = price * _CENT_MULTIPLIER
 
-        return price
+        return round(price, self._precision)
 
     def _update(self):
         """Set attrs"""


### PR DESCRIPTION
#244 introduced a regression where prices are no longer rounded by precision specified in the configuration. Re-add the `round`-statement before returning the price.

Should hopefully fix #271 