### PR TITLE
Fixing the "currency" key not present in the response

### DIFF
--- a/custom_components/nordpool/__init__.py
+++ b/custom_components/nordpool/__init__.py
@@ -70,17 +70,11 @@ class NordpoolData:
         # Keeping this for now, but this should be changed.
         for currency in self.currency:
             spot = AioPrices(currency, client)
-
-            success = False
-
             data = await spot.hourly(end_date=dt)
             if data:
                 self._data[currency][type_] = data["areas"]
-                success = True
             else:
                 _LOGGER.info("Some crap happend, retrying request later.")
-
-            if not success:
                 async_call_later(hass, 20, partial(self._update, type_=type_, dt=dt))
 
     async def update_today(self, _: datetime):

--- a/custom_components/nordpool/__init__.py
+++ b/custom_components/nordpool/__init__.py
@@ -70,11 +70,17 @@ class NordpoolData:
         # Keeping this for now, but this should be changed.
         for currency in self.currency:
             spot = AioPrices(currency, client)
+
+            success = False
+
             data = await spot.hourly(end_date=dt)
             if data:
                 self._data[currency][type_] = data["areas"]
+                success = True
             else:
                 _LOGGER.info("Some crap happend, retrying request later.")
+
+            if not success:
                 async_call_later(hass, 20, partial(self._update, type_=type_, dt=dt))
 
     async def update_today(self, _: datetime):


### PR DESCRIPTION
I have been getting following error when HA integration fails to update tomorrow's prices:

`
2023-02-22 14:14:46.001 DEBUG (MainThread) [custom_components.nordpool] Updating tomorrows prices.
2023-02-22 14:14:46.002 DEBUG (MainThread) [custom_components.nordpool] calling _update tomorrow 2023-02-23 14:14:46.002047+02:00
2023-02-22 14:15:13.899 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=EUR&endDate=23-02-2023 {'currency': 'EUR', 'endDate': '23-02-2023'}
2023-02-22 14:15:13.904 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=EUR&endDate=22-02-2023 {'currency': 'EUR', 'endDate': '22-02-2023'}
2023-02-22 14:15:13.904 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=EUR&endDate=21-02-2023 {'currency': 'EUR', 'endDate': '21-02-2023'}
2023-02-22 14:15:13.905 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/config/custom_components/nordpool/__init__.py", line 152, in new_data_cb
    await api.update_tomorrow(tdo)
  File "/config/custom_components/nordpool/__init__.py", line 88, in update_tomorrow
    await self._update(type_="tomorrow", dt=dt_utils.now() + timedelta(hours=24))
  File "/config/custom_components/nordpool/__init__.py", line 73, in _update
    data = await spot.hourly(end_date=dt)
  File "/config/custom_components/nordpool/aio_price.py", line 263, in hourly
    return await self.fetch(self.HOURLY, end_date, areas)
  File "/config/custom_components/nordpool/aio_price.py", line 256, in fetch
    raw = [self._parse_json(i, areas) for i in res]
  File "/config/custom_components/nordpool/aio_price.py", line 256, in <listcomp>
    raw = [self._parse_json(i, areas) for i in res]
  File "/usr/local/lib/python3.10/site-packages/nordpool/elspot.py", line 37, in _parse_json
    currency = data['currency']
KeyError: 'currency'
`

This is an attempt to fix it, do not parse_json if the "currency" key is missing from the response.