### PR TITLE
fix: template_value was made positive if price was negative

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -311,8 +311,6 @@ class NordpoolSensor(SensorEntity):
 
         self._additional_costs_value = template_value
         try:
-            # If the price is negative, subtract the additional costs from the price
-            template_value = abs(template_value) if price < 0 else template_value
             price += template_value
         except Exception:
             _LOGGER.debug(


### PR DESCRIPTION
I couldn't figure out the reason for `abs(template_value)`. 
I have a template evaluating to `-0.002` and when the electricity price is `-0.00092` the final price evaluates to `0.00108`. I would expect it to be `-0.00292`.