### PR TITLE
Fix issue with late published prices

### DIFF
--- a/custom_components/nordpool/__init__.py
+++ b/custom_components/nordpool/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.event import async_track_time_change
 from homeassistant.util import dt as dt_utils
 from pytz import timezone
 
-from .aio_price import AioPrices
+from .aio_price import AioPrices, InvalidValueException
 from .events import async_track_time_change_in_tz
 
 DOMAIN = "nordpool"
@@ -97,7 +97,10 @@ class NordpoolData:
         if currency not in self.currency:
             self.currency.append(currency)
             await self.update_today()
-            await self.update_tomorrow()
+            try:
+                await self.update_tomorrow()
+            except InvalidValueException:
+                _LOGGER.debug("No data available for tomorrow, retrying later")
 
             # Send a new data request after new data is updated for this first run
             # This way if the user has multiple sensors they will all update

--- a/custom_components/nordpool/aio_price.py
+++ b/custom_components/nordpool/aio_price.py
@@ -90,6 +90,12 @@ AREA_TO_COUNTRY = {
     "PL ": "PL",
 }
 
+INVALID_VALUES = frozenset((None, float("inf")))
+
+
+class InvalidValueException(ValueError):
+    pass
+
 
 def join_result_for_correct_time(results, dt):
     """Parse a list of responses from the api
@@ -135,6 +141,8 @@ def join_result_for_correct_time(results, dt):
                 local = val["start"].astimezone(zone)
                 local_end = val["end"].astimezone(zone)
                 if start_of_day <= local and local <= end_of_day:
+                    if val['value'] in INVALID_VALUES:
+                        raise InvalidValueException()
                     if local == local_end:
                         _LOGGER.info(
                             "Hour has the same start and end, most likly due to dst change %s exluded this hour",

--- a/custom_components/nordpool/aio_price.py
+++ b/custom_components/nordpool/aio_price.py
@@ -179,7 +179,10 @@ class AioPrices(Prices):
 
     # Add more exceptions as we find them. KeyError is raised when the api return
     # junk due to currency not being available in the data.
-    @backoff.on_exception(backoff.expo, (aiohttp.ClientError, KeyError), logger=_LOGGER)
+    @backoff.on_exception(
+        backoff.expo,
+        (aiohttp.ClientError, KeyError),
+        logger=_LOGGER, max_value=20, max_time=60)
     async def fetch(self, data_type, end_date=None, areas=None):
         """
         Fetch data from API.


### PR DESCRIPTION
* Limit backoff and maximum time to retry for AioPrices.fetch()
* Add constant to hold invalid values and use instead of repeating
* Move tomorrow_valid functionality to NordpoolData
* Only send EVENT_NEW_PRICE signal if new data is available
* Retry polling for new data hourly if needed

Fixes #326 