### PR TITLE
Pass areas down to aio_price.py to avoid errors unrelated to selected area

### DIFF
--- a/custom_components/nordpool/aio_price.py
+++ b/custom_components/nordpool/aio_price.py
@@ -142,7 +142,7 @@ def join_result_for_correct_time(results, dt):
                 local_end = val["end"].astimezone(zone)
                 if start_of_day <= local and local <= end_of_day:
                     if val['value'] in INVALID_VALUES:
-                        raise InvalidValueException()
+                        raise InvalidValueException(f"Invalid value in {val} for area '{key}'")
                     if local == local_end:
                         _LOGGER.info(
                             "Hour has the same start and end, most likly due to dst change %s exluded this hour",


### PR DESCRIPTION
Fixes #338 

This PR adds a try-except when fetching prices for today, to avoid complete failures and stacktraces in the log. If this is undesired, feel free to remove it.

This PR also changed some functions to keep a list of fetched areas and pass them to the underlying functions, so only values in the areas of interest are parsed, and therefore only invalid data in those areas will result in an exception.

I've tested the code on my private instance for several days, and it fetches the correct area with exceptions at the correct time

Due to `aio_price.fetch` fetching all areas, a single invalid value in the time-range for any area will result in raising an `InvalidValueException`, which wasn't handled and thus results in failure. My instance is only set up to track DK1, and with some more logging i found out that the error was caused by an invalid value for the AT-area:
```
2023-08-28 11:28:35.980 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 12, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 13, 0, tzinfo=<UTC>), 'value': 861.41}
2023-08-28 11:28:35.980 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 13, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 14, 0, tzinfo=<UTC>), 'value': 908.06}
2023-08-28 11:28:35.980 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 14, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 15, 0, tzinfo=<UTC>), 'value': 1227.42}
2023-08-28 11:28:35.980 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 15, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 16, 0, tzinfo=<UTC>), 'value': 1118.39}
2023-08-28 11:28:35.981 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 16, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 17, 0, tzinfo=<UTC>), 'value': 1344.06}
2023-08-28 11:28:35.981 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 17, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 18, 0, tzinfo=<UTC>), 'value': 1632.26}
2023-08-28 11:28:35.981 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 18, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 19, 0, tzinfo=<UTC>), 'value': 1519.8}
2023-08-28 11:28:35.981 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 19, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 20, 0, tzinfo=<UTC>), 'value': 1093.19}
2023-08-28 11:28:35.981 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing LT : {'start': datetime.datetime(2023, 8, 28, 20, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 28, 21, 0, tzinfo=<UTC>), 'value': 922.08}
2023-08-28 11:28:35.981 DEBUG (MainThread) [custom_components.nordpool.aio_price] Parsing AT : {'start': datetime.datetime(2023, 8, 27, 22, 0, tzinfo=<UTC>), 'end': datetime.datetime(2023, 8, 27, 23, 0, tzinfo=<UTC>), 'value': inf}
2023-08-28 11:28:35.983 ERROR (MainThread) [homeassistant.components.sensor] Error adding entities for domain sensor with platform nordpool
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 510, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 750, in _async_add_entity
[...]
```

Debuglog before this PR:
```
2023-08-28 10:42:53.121 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=DKK&endDate=27-08-2023 {'currency': 'DKK', 'endDate': '27-08-2023'}
2023-08-28 10:42:53.145 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=DKK&endDate=28-08-2023 {'currency': 'DKK', 'endDate': '28-08-2023'}
2023-08-28 10:42:53.205 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=DKK&endDate=29-08-2023 {'currency': 'DKK', 'endDate': '29-08-2023'}
2023-08-28 10:42:53.267 ERROR (MainThread) [homeassistant.components.sensor] Error adding entities for domain sensor with platform nordpool
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 510, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 750, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1003, in add_to_platform_finish
    await self.async_added_to_hass()
  File "/config/custom_components/nordpool/sensor.py", line 518, in async_added_to_hass
    await self.handle_new_hr()
  File "/config/custom_components/nordpool/sensor.py", line 480, in handle_new_hr
    today = await self._api.today(self._area, self._currency)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/nordpool/__init__.py", line 113, in today
    return await self._someday(area, currency, "today")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/nordpool/__init__.py", line 99, in _someday
    await self.update_today()
  File "/config/custom_components/nordpool/__init__.py", line 80, in update_today
    await self._update("today")
  File "/config/custom_components/nordpool/__init__.py", line 73, in _update
    data = await spot.hourly(end_date=dt)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/nordpool/aio_price.py", line 239, in hourly
    return await self.fetch(self.HOURLY, end_date, areas)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/backoff/_async.py", line 151, in retry
    ret = await target(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/nordpool/aio_price.py", line 233, in fetch
    return join_result_for_correct_time(raw, end_date)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/nordpool/aio_price.py", line 145, in join_result_for_correct_time
    raise InvalidValueException()
custom_components.nordpool.aio_price.InvalidValueException
```

Debuglog after: 
```
2023-08-28 11:52:30.004 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=DKK&endDate=27-08-2023 {'currency': 'DKK', 'endDate': '27-08-2023'}
2023-08-28 11:52:30.015 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=DKK&endDate=28-08-2023 {'currency': 'DKK', 'endDate': '28-08-2023'}
2023-08-28 11:52:30.220 DEBUG (MainThread) [custom_components.nordpool.aio_price] requested https://www.nordpoolgroup.com/api/marketdata/page/10?currency=DKK&endDate=29-08-2023 {'currency': 'DKK', 'endDate': '29-08-2023'}
2023-08-28 11:52:30.242 DEBUG (MainThread) [custom_components.nordpool] No data available for tomorrow, retrying later
2023-08-28 11:52:30.243 DEBUG (MainThread) [custom_components.nordpool.sensor] Updated nordpool_kwh_dk1_dkk_2_00_025 _current_price 856.04
2023-08-28 11:52:30.246 DEBUG (MainThread) [custom_components.nordpool.sensor] handle_new_hr
```