### PR TITLE
Remove unnecessary call to template.attach

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_REGION
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.template import Template, attach
+from homeassistant.helpers.template import Template
 from homeassistant.util import dt as dt_utils
 
 # Import sensor entity and classes.
@@ -197,8 +197,6 @@ class NordpoolSensor(SensorEntity):
         else:
             if self._ad_template.template in ("", None):
                 self._ad_template = cv.template(DEFAULT_TEMPLATE)
-
-        attach(self._hass, self._ad_template)
 
         # To control the updates.
         self._last_tick = None


### PR DESCRIPTION
Remove unnecessary call to `template.attach`

Since Home Assistant Core 2023.4 it's no longer needed to call `template.attach` : https://github.com/home-assistant/core/pull/89242

Note: I have not tested the change, the PR is created in preparation for removing the `template.attach` function from Home Assistant Core because it no longer serves any purpose.