### PR TITLE
Add option to define unique_id in yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ mv nordpool-X.Y.Z/custom_components/nordpool/* .
 | Price in cents       | no       | *Default: false* <br> Display price in cents in stead of (for example) Euros.|
 | Energy scale         | no       | *Default: kWh* <br> Price displayed for MWh, kWh or Wh.|
 | Additional Cost      | no       |  *default `{{0.0\|float}}`* <br> Template to specify additional cost to be added. See [Additional Costs](#additional-costs) for more details.|
+| Entity Id            | no       | *Default: Generated automatically based on scale, region, currency, precision, low price precentage and vat. |
 
 ### Option 1: UI
 - Go to `Settings` -> `Devices & Services`
@@ -108,6 +109,11 @@ sensor:
     # The template price is in EUR, DKK, NOK or SEK (not in cents).
     # For example: "{{ current_price * 0.19 + 0.023 | float}}" 
     additional_costs: "{{0.0|float}}"
+
+    # Can be used to override default generated entity id.
+    # Enter only part after "sensor."
+    # Lower case and no spaces
+    unique_id: nordpool_custom
 ```
 ### Regions
 See the [Nord Pool region map](https://www.nordpoolgroup.com/en/maps/) for details

--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -83,6 +83,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional("price_type", default="kWh"): vol.In(list(_PRICE_IN.keys())),
         vol.Optional("price_in_cents", default=False): cv.boolean,
         vol.Optional("additional_costs", default=DEFAULT_TEMPLATE): cv.template,
+        vol.Optional("unique_id"): cv.string,
     }
 )
 
@@ -101,6 +102,7 @@ def _dry_setup(hass, config, add_devices, discovery_info=None):
     use_cents = config.get("price_in_cents")
     ad_template = config.get("additional_costs")
     api = hass.data[DOMAIN]
+    unique_id = config.get("unique_id")
     sensor = NordpoolSensor(
         friendly_name,
         region,
@@ -113,6 +115,7 @@ def _dry_setup(hass, config, add_devices, discovery_info=None):
         api,
         ad_template,
         hass,
+        unique_id,
     )
 
     add_devices([sensor])
@@ -148,6 +151,7 @@ class NordpoolSensor(SensorEntity):
         api,
         ad_template,
         hass,
+        unique_id=None,
     ) -> None:
         self._area = area
         self._currency = currency or _REGIONS[area][0]
@@ -161,6 +165,7 @@ class NordpoolSensor(SensorEntity):
         self._ad_template = ad_template
         self._hass = hass
         self._attr_force_update = True
+        self._user_unique_id = unique_id
 
         if vat is True:
             self._vat = _REGIONS[area][2]
@@ -228,6 +233,9 @@ class NordpoolSensor(SensorEntity):
 
     @property
     def unique_id(self):
+        if self._user_unique_id:
+            return self._user_unique_id
+        
         name = "nordpool_%s_%s_%s_%s_%s_%s" % (
             self._price_type,
             self._area,


### PR DESCRIPTION
Added option for user to configure unique_id that is used as entity id.
This can help people who use Nordpool sensor in alot of places.