### PR TITLE
 Fix version number in HA

### DIFF
--- a/custom_components/nordpool/manifest.json
+++ b/custom_components/nordpool/manifest.json
@@ -16,5 +16,5 @@
     "nordpool>=0.2",
     "backoff"
   ],
-  "version": "0.0.14"
+  "version": "0.0.16"
 }


### PR DESCRIPTION
Version is still showing 0.0.14 in HA, this bumps up the manifest version to 0.0.16 so you can make a new release.

<img width="498" alt="image" src="https://github.com/user-attachments/assets/507f74a8-1636-4e4c-b4ee-31720b703953">
