### PR TITLE
Issue #438: Pin version of nordpool package

### DIFF
--- a/custom_components/nordpool/manifest.json
+++ b/custom_components/nordpool/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/custom-components/nordpool/issues",
   "requirements": [
-    "nordpool>=0.2",
+    "nordpool==0.4.2",
     "backoff"
   ],
   "version": "0.0.16"


### PR DESCRIPTION
Apparently the nordpool package introduced a backwards incompatibility in the 0.4.3 minor version. This just pins the package to version 0.4.2.