### PR TITLE
Issue #438: Fix import-path of CurrencyMismatch

### DIFF
--- a/custom_components/nordpool/aio_price.py
+++ b/custom_components/nordpool/aio_price.py
@@ -7,8 +7,7 @@ import aiohttp
 import backoff
 from dateutil.parser import parse as parse_dt
 from homeassistant.util import dt as dt_utils
-from nordpool.base import CurrencyMismatch
-from nordpool.elspot import Prices
+from nordpool.elspot import CurrencyMismatch, Prices
 from pytz import timezone, utc
 
 from .misc import add_junk

--- a/custom_components/nordpool/manifest.json
+++ b/custom_components/nordpool/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/custom-components/nordpool/issues",
   "requirements": [
-    "nordpool>=0.2",
+    "nordpool>=0.4.3,<1",
     "backoff"
   ],
   "version": "0.0.16"

--- a/custom_components/nordpool/test_parser.py
+++ b/custom_components/nordpool/test_parser.py
@@ -9,8 +9,7 @@ from aiozoneinfo import async_get_time_zone
 # https://repl.it/repls/WildImpishMass
 from dateutil import tz
 from dateutil.parser import parse as parse_dt
-from nordpool.base import CurrencyMismatch
-from nordpool.elspot import Prices
+from nordpool.elspot import CurrencyMismatch, Prices
 
 _LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)


### PR DESCRIPTION
Fixed the import-path of `CurrencyMismatch` from `base` -> `elspot`, based on recommendation of the author in [this issue](https://github.com/kipe/nordpool/issues/56#issuecomment-2456422169), and pinned the nordpool-package to `>=0.4.3,<1` to avoid jumping major versions in the future.

A lot of users are affected since the release of 2024.11, many will be upgrading their homeassistant-instance, and therefore the nordpool package - this is what happened to me.

I believe this is a better fix than PR #439 

Tested in my private homeassistant

Fixes issue #438