### PR TITLE
negative prices vat should do correct calculation

### DIFF
--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -261,7 +261,7 @@ class NordpoolSensor(SensorEntity):
 
             return pass_context(inner)
 
-        price = value / _PRICE_IN[self._price_type] * (float(1 + self._vat))
+        price = value / _PRICE_IN[self._price_type] + (_PRICE_IN[self._price_type]*float(self._vat))
         template_value = self._ad_template.async_render(
             now=faker(), current_price=price
         )


### PR DESCRIPTION
negative prices like -0.1 should not be increased by vat, say 25%,  to become -0.125 because this is wrong when calculating it as price*1.25

