### PR TITLE
Implement quarterhourly prices

### DIFF
--- a/custom_components/nordpool/const.py
+++ b/custom_components/nordpool/const.py
@@ -4,7 +4,7 @@ from random import randint
 DOMAIN = "nordpool"
 RANDOM_MINUTE = randint(10, 30)
 RANDOM_SECOND = randint(0, 59)
-EVENT_NEW_HOUR = "nordpool_update_hour"
+EVENT_NEW_QUARTERHOUR = "nordpool_update_quarterhour"
 EVENT_NEW_DAY = "nordpool_update_day"
 EVENT_NEW_PRICE = "nordpool_update_new_price"
 SENTINEL = object()

--- a/custom_components/nordpool/misc.py
+++ b/custom_components/nordpool/misc.py
@@ -14,8 +14,6 @@ __all__ = [
     "is_new",
     "has_junk",
     "extract_attrs",
-    "start_of",
-    "end_of",
     "stock",
     "add_junk",
 ]
@@ -54,29 +52,12 @@ def stock(d):
     """convert datetime to stocholm time."""
     return d.astimezone(stockholm_tz)
 
-
-def start_of(d, typ_="hour"):
-    if typ_ == "hour":
-        return d.replace(minute=0, second=0, microsecond=0)
-    elif typ_ == "day":
-        return d.replace(hour=0, minute=0, microsecond=0)
-
-
 def time_in_range(start, end, x):
     """Return true if x is in the range [start, end]"""
     if start <= end:
         return start <= x <= end
     else:
         return start <= x or x <= end
-
-
-def end_of(d, typ_="hour"):
-    """Return end our hour"""
-    if typ_ == "hour":
-        return d.replace(minute=59, second=59, microsecond=999999)
-    elif typ_ == "day":
-        return d.replace(hour=23, minute=59, second=59, microsecond=999999)
-
 
 def is_new(date=None, typ="day") -> bool:
     """Utility to check if its a new hour or day."""

--- a/custom_components/nordpool/services.py
+++ b/custom_components/nordpool/services.py
@@ -28,7 +28,7 @@ def check_setting(value):
     return validator
 
 
-HOURLY_SCHEMA = vol.Schema(
+QUARTERHOURLY_SCHEMA = vol.Schema(
     {
         vol.Required("currency"): str,
         vol.Required("date"): cv.date,
@@ -54,16 +54,16 @@ async def async_setup_services(hass: HomeAssistant):
 
     client = async_get_clientsession(hass)
 
-    async def hourly(service_call: ServiceCall) -> Any:
+    async def quarterhourly(service_call: ServiceCall) -> Any:
         sc = service_call.data
-        _LOGGER.debug("called hourly with %r", sc)
+        _LOGGER.debug("called quarterhourly with %r", sc)
 
         # Convert the date to datetime as the rest of the code expects a datetime. We will want to keep date as it easier for ppl to use.
         end_date = datetime(
             year=sc["date"].year, month=sc["date"].month, day=sc["date"].day
         )
 
-        value = await AioPrices(sc["currency"], client).hourly(
+        value = await AioPrices(sc["currency"], client).quarterhourly(
             areas=sc["area"], end_date=end_date, raw=True
         )
 
@@ -114,9 +114,9 @@ async def async_setup_services(hass: HomeAssistant):
 
     hass.services.async_register(
         domain="nordpool",
-        service="hourly",
-        service_func=hourly,
-        schema=HOURLY_SCHEMA,
+        service="quarterhourly",
+        service_func=quarterhourly,
+        schema=QUARTERHOURLY_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(

--- a/custom_components/nordpool/services.yaml
+++ b/custom_components/nordpool/services.yaml
@@ -44,10 +44,10 @@ monthly:
       description: "Return the prices for what price area"
       example: "NO2"
 
-hourly:
-  name: hourly
+quarterhourly:
+  name: quarterhourly
   description: >-
-    Action that gets the raw hourly price for spesific date from Nordpool
+    Action that gets the raw quarterhourly price for spesific date from Nordpool
   fields:
     currency:
       description: "What currecy should the prices be returned in"


### PR DESCRIPTION
I've done some minor refactoring/renaming and added more scheduled jobs to update the price-sensor every 15 minutes instead of each hour. This enabled 15-minute prices in my local installation:

<img width="1242" height="537" alt="image" src="https://github.com/user-attachments/assets/b5d391a0-2440-44ad-9688-55ef56cb1bae" />


Only tested in my local homeassistant-installation.

I've not updated any of the documentation or examples, only the code.

Fixes #496 #477