### PR TITLE
Fix weekly service calling yearly method instead of weekly

### DIFF
--- a/custom_components/nordpool/services.py
+++ b/custom_components/nordpool/services.py
@@ -85,7 +85,7 @@ async def async_setup_services(hass: HomeAssistant):
         sc = service_call.data
         _LOGGER.debug("called weekly with %r", sc)
 
-        value = await AioPrices(sc["currency"], client).yearly(
+        value = await AioPrices(sc["currency"], client).weekly(
             areas=sc["area"], end_date=sc["year"]
         )
 


### PR DESCRIPTION
## Summary
- Fixed a copy-paste bug where the `weekly` service handler was incorrectly calling `AioPrices.yearly()` instead of `AioPrices.weekly()`
- This caused `nordpool.weekly` service to return yearly aggregated data instead of weekly data

## Test plan
- [x] Verified bug exists by calling `nordpool.weekly` and `nordpool.yearly` services - both returned identical yearly data
- [ ] After fix, `nordpool.weekly` should return weekly aggregated data with ~52 data points per year