### PR TITLE
Add OptionsFlow support for post-installation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ mv nordpool-X.Y.Z/custom_components/nordpool/* .
 - Search for `nordpool` and select it
 - Fill in the required values and press `Submit`
 
-Tip: By default, the integration will create a device with the name `nordpool_<energy_scale>_<region>_<currency>_<some-numbers>`. It is recommended to rename the device and all its entities to `nordpool`. If you need to recreate your sensor (for example, to change the additional cost), all automations and dashboards keep working.
+#### Changing settings after installation
+To modify settings after installation:
+- Go to `Settings` -> `Devices & Services` -> `Nordpool`
+- Click `Configure` on your sensor entry
+- Adjust settings and click `Submit`
+
+Note: Region cannot be changed after initial setup. All other settings can be modified.
+
+Tip: By default, the integration will create a device with the name `nordpool_<entry_id>`. It is recommended to rename the device and all its entities to something meaningful like `nordpool`.
 
 ### Option 2: YAML
 Set up the sensor using in `configuration.yaml`.
@@ -140,7 +148,7 @@ There are two special special arguments in that can be used in the template ([in
 - ```now()```: this always refer to the current hour of the price
 - ```current_price```: price for the current hour. This can be used for example be used to calculate your own VAT or add overhead cost.
 
-Note: When configuring Nordpool using the UI, things like VAT and additional costs cannot be changed. If your energy supplier or region changes the additional costs or taxes on a semi-regular basis, the YAML configuration or a helper (example 4) work best.
+Note: When configuring Nordpool using the UI, you can change settings after installation by clicking the "Configure" button on the integration page. Region cannot be changed after initial setup. If your energy supplier changes additional costs or taxes frequently, using a helper (example 4) is recommended.
 
 #### Example 1: Overhead per kWh
 

--- a/custom_components/nordpool/config_flow.py
+++ b/custom_components/nordpool/config_flow.py
@@ -1,9 +1,13 @@
 """Adds config flow for nordpool."""
 import logging
 import re
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry, OptionsFlow
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.template import Template
 
 from . import DOMAIN
@@ -20,6 +24,12 @@ class NordpoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> "NordpoolOptionsFlowHandler":
+        """Create the options flow."""
+        return NordpoolOptionsFlowHandler()
 
     def __init__(self):
         """Initialize."""
@@ -96,3 +106,67 @@ class NordpoolFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         Instead, we're going to rely on the values that are in config file.
         """
         return self.async_create_entry(title="configuration.yaml", data={})
+
+
+class NordpoolOptionsFlowHandler(OptionsFlow):
+    """Handle Nordpool options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            if user_input.get("additional_costs"):
+                user_input["additional_costs"] = re.sub(
+                    r"\s{2,}", "", user_input["additional_costs"]
+                )
+                if not await self._valid_template(user_input["additional_costs"]):
+                    errors["base"] = "invalid_template"
+            else:
+                user_input["additional_costs"] = DEFAULT_TEMPLATE
+
+            if not errors:
+                return self.async_create_entry(title="", data=user_input)
+
+        # Get current values (options override data for existing entries)
+        current = {**self.config_entry.data, **self.config_entry.options}
+
+        options_schema = vol.Schema(
+            {
+                vol.Optional(
+                    "currency", default=current.get("currency", "")
+                ): vol.In(currencys),
+                vol.Optional("VAT", default=current.get("VAT", True)): bool,
+                vol.Optional(
+                    "precision", default=current.get("precision", 3)
+                ): vol.Coerce(int),
+                vol.Optional(
+                    "low_price_cutoff", default=current.get("low_price_cutoff", 1.0)
+                ): vol.Coerce(float),
+                vol.Optional(
+                    "price_in_cents", default=current.get("price_in_cents", False)
+                ): bool,
+                vol.Optional(
+                    "price_type", default=current.get("price_type", "kWh")
+                ): vol.In(price_types),
+                vol.Optional(
+                    "additional_costs", default=current.get("additional_costs", "")
+                ): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=options_schema,
+            errors=errors,
+        )
+
+    async def _valid_template(self, user_template: str) -> bool:
+        """Validate Jinja2 template."""
+        try:
+            ut = Template(user_template, self.hass).async_render(current_price=0)
+            return isinstance(ut, float)
+        except Exception:
+            return False

--- a/custom_components/nordpool/sensor.py
+++ b/custom_components/nordpool/sensor.py
@@ -59,7 +59,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def _dry_setup(hass, config, add_devices, discovery_info=None):
+def _dry_setup(hass, config, add_devices, discovery_info=None, config_entry=None):
     """Setup the damn platform using yaml."""
     _LOGGER.debug("Dumping config %r", config)
     _LOGGER.debug("timezone set in ha %r", hass.config.time_zone)
@@ -85,6 +85,7 @@ def _dry_setup(hass, config, add_devices, discovery_info=None):
         api,
         ad_template,
         hass,
+        config_entry,
     )
 
     add_devices([sensor])
@@ -97,8 +98,9 @@ async def async_setup_platform(hass, config, add_devices, discovery_info=None) -
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Setup sensor platform for the ui"""
-    config = config_entry.data
-    _dry_setup(hass, config, async_add_devices)
+    # Merge data and options, with options taking precedence
+    config = {**config_entry.data, **config_entry.options}
+    _dry_setup(hass, config, async_add_devices, config_entry=config_entry)
     return True
 
 
@@ -126,6 +128,7 @@ class NordpoolSensor(SensorEntity):
         api,
         ad_template,
         hass,
+        config_entry=None,
     ) -> None:
         self._area = area
         self._currency = currency or _REGIONS[area][0]
@@ -138,6 +141,7 @@ class NordpoolSensor(SensorEntity):
         self._api = api
         self._ad_template = ad_template
         self._hass = hass
+        self._config_entry = config_entry
         self._attr_force_update = True
 
         if vat is True:
@@ -206,6 +210,11 @@ class NordpoolSensor(SensorEntity):
 
     @property
     def unique_id(self):
+        # Use entry_id for UI-configured sensors (stable across option changes)
+        # Fall back to legacy format for YAML-configured sensors
+        if self._config_entry is not None:
+            return f"nordpool_{self._config_entry.entry_id}"
+        # Legacy unique_id for YAML configurations
         name = "nordpool_%s_%s_%s_%s_%s_%s" % (
             self._price_type,
             self._area,

--- a/custom_components/nordpool/translations/da.json
+++ b/custom_components/nordpool/translations/da.json
@@ -22,5 +22,25 @@
             "name_exists": "Navnet eksisterer allerede",
             "invalid_template": "Skabelonen indeholder fejl, se https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Indstillinger",
+                "description": "Konfigurer dine Nordpool-sensorindstillinger. Bemærk: Region kan ikke ændres efter opsætning.",
+                "data": {
+                    "currency": "Valuta",
+                    "VAT": "Inkludér moms",
+                    "precision": "Antal decimaler som vises",
+                    "low_price_cutoff": "Grænse for lav-pris",
+                    "price_in_cents": "Pris i øre",
+                    "price_type": "Prisformat",
+                    "additional_costs": "Skabelon for yderligere omkostninger"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Skabelonen indeholder fejl, se https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/en.json
+++ b/custom_components/nordpool/translations/en.json
@@ -21,5 +21,25 @@
             "name_exists": "Name already exists",
             "invalid_template": "The template is invalid, check https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Options",
+                "description": "Configure your Nordpool sensor settings. Note: Region cannot be changed after setup.",
+                "data": {
+                    "currency": "Currency",
+                    "VAT": "Include VAT",
+                    "precision": "Decimal rounding precision",
+                    "low_price_cutoff": "Low price percentage",
+                    "price_in_cents": "Price in cents",
+                    "price_type": "Energy scale",
+                    "additional_costs": "Template for additional costs"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "The template is invalid, check https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/et.json
+++ b/custom_components/nordpool/translations/et.json
@@ -21,7 +21,26 @@
         "error": {
             "name_exists": "See nimi on juba kasutusel",
             "invalid_template": "See mall on vigane, vaata https://github.com/custom-components/nordpool"
-
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Elektri börsihinna seaded",
+                "description": "Muuda anduri seadeid. Märkus: Piirkonda ei saa pärast seadistamist muuta.",
+                "data": {
+                    "currency": "Valuuta",
+                    "VAT": "Koos käibemaksuga",
+                    "precision": "Mitu kohta peale koma",
+                    "low_price_cutoff": "Madala hinna tase",
+                    "price_in_cents": "Hind sentides",
+                    "price_type": "Hinna vorming",
+                    "additional_costs": "Lisanduvate hindade mall"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "See mall on vigane, vaata https://github.com/custom-components/nordpool"
         }
     }
 }

--- a/custom_components/nordpool/translations/fi.json
+++ b/custom_components/nordpool/translations/fi.json
@@ -22,5 +22,25 @@
             "name_exists": "Nimi on jo käytössä",
             "invalid_template": "Template on virheellinen, katso https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool asetukset",
+                "description": "Muokkaa Nordpool sensorin asetuksia. Huomio: Aluetta ei voi muuttaa asennuksen jälkeen.",
+                "data": {
+                    "currency": "Valuutta",
+                    "VAT": "Sisällytä ALV",
+                    "precision": "Desimaalien lukumäärä",
+                    "low_price_cutoff": "Matalan hinnan raja-arvo",
+                    "price_in_cents": "Hinta senteissä",
+                    "price_type": "Hinnan yksikkö",
+                    "additional_costs": "Sivukulujen laskenta Template"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Template on virheellinen, katso https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/lv.json
+++ b/custom_components/nordpool/translations/lv.json
@@ -21,5 +21,25 @@
             "name_exists": "Šāds nosaukums jau eksistē",
             "invalid_template": "Veidne nav korekta, skatīt https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Iestatījumi",
+                "description": "Konfigurējiet Nordpool sensora iestatījumus. Piezīme: Reģionu nevar mainīt pēc iestatīšanas.",
+                "data": {
+                    "currency": "Valūta",
+                    "VAT": "Iekļaut PVN",
+                    "precision": "Decimāldaļas noapaļošanas precizitāte",
+                    "low_price_cutoff": "Zemās cenas līmenis procentos",
+                    "price_in_cents": "Cena centos",
+                    "price_type": "Cenas formāts",
+                    "additional_costs": "Papildus izmaksu veidne"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Veidne nav korekta, skatīt https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/nb.json
+++ b/custom_components/nordpool/translations/nb.json
@@ -21,5 +21,25 @@
             "name_exists": "Navnet eksisterer allerede",
             "invalid_template": "Malen inneholder feil, se https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Innstillinger",
+                "description": "Konfigurer Nordpool-sensorinnstillingene dine. Merk: Region kan ikke endres etter oppsett.",
+                "data": {
+                    "currency": "Valuta",
+                    "VAT": "Inkluder MVA",
+                    "precision": "Antall desimaler som vises",
+                    "low_price_cutoff": "Grense for lav-pris",
+                    "price_in_cents": "Pris i øre",
+                    "price_type": "Pris i format",
+                    "additional_costs": "Mal for tilleggskostnader"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Malen inneholder feil, se https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/nl.json
+++ b/custom_components/nordpool/translations/nl.json
@@ -21,5 +21,25 @@
             "name_exists": "Naam bestaat al",
             "invalid_template": "Het template is ongeldig, zie https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Instellingen",
+                "description": "Configureer uw Nordpool sensor instellingen. Let op: Regio kan niet worden gewijzigd na installatie.",
+                "data": {
+                    "currency": "Munteenheid",
+                    "VAT": "Inclusief BTW",
+                    "precision": "Decimalen afronden",
+                    "low_price_cutoff": "Precentage lage prijs",
+                    "price_in_cents": "Prijs in centen",
+                    "price_type": "Energie schaal",
+                    "additional_costs": "Template voor extra kosten"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Het template is ongeldig, zie https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/nn.json
+++ b/custom_components/nordpool/translations/nn.json
@@ -21,5 +21,25 @@
             "name_exists": "Namnet eksisterer allereie",
             "invalid_template": "Malen inneheld ein feil, sjå https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Innstillingar",
+                "description": "Konfigurer Nordpool-sensorinnstillingane dine. Merk: Region kan ikkje endrast etter oppsett.",
+                "data": {
+                    "currency": "Valuta",
+                    "VAT": "Inkluder MVA",
+                    "precision": "Talet på desimal som vert vist",
+                    "low_price_cutoff": "Grense for låg-pris",
+                    "price_in_cents": "Pris i øre",
+                    "price_type": "Pris i format",
+                    "additional_costs": "Mal for tilleggskostnadar"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Malen inneheld ein feil, sjå https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/sk.json
+++ b/custom_components/nordpool/translations/sk.json
@@ -21,5 +21,25 @@
             "name_exists": "Názov už existuje",
             "invalid_template": "Šablóna je neplatná, skontrolujte https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nordpool Nastavenia",
+                "description": "Nakonfigurujte nastavenia snímača Nordpool. Poznámka: Región nie je možné zmeniť po nastavení.",
+                "data": {
+                    "currency": "Mena",
+                    "VAT": "Vrátane DPH",
+                    "precision": "Presnosť desatinného zaokrúhľovania",
+                    "low_price_cutoff": "Nízke percento ceny",
+                    "price_in_cents": "Cena v centoch",
+                    "price_type": "Energetická stupnica",
+                    "additional_costs": "Šablóna pre dodatočné náklady"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Šablóna je neplatná, skontrolujte https://github.com/custom-components/nordpool"
+        }
     }
 }

--- a/custom_components/nordpool/translations/sv.json
+++ b/custom_components/nordpool/translations/sv.json
@@ -22,5 +22,25 @@
             "name_exists": "Namnet existerar redan",
             "invalid_template": "Mallen är ogiltig, se https://github.com/custom-components/nordpool"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Nord Pool Inställningar",
+                "description": "Konfigurera dina Nord Pool-sensorinställningar. Obs: Region kan inte ändras efter installation.",
+                "data": {
+                    "currency": "Valuta",
+                    "VAT": "Inkludera moms",
+                    "precision": "Hur många decimaler ska visas",
+                    "low_price_cutoff": "Lägsta prisnivå",
+                    "price_in_cents": "Pris i ören",
+                    "price_type": "Prisformat",
+                    "additional_costs": "Mall för ytterligare kostnader"
+                }
+            }
+        },
+        "error": {
+            "invalid_template": "Mallen är ogiltig, se https://github.com/custom-components/nordpool"
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add OptionsFlow support to allow changing sensor settings after initial installation via the UI "Configure" button.

**Changes:**
- Add `NordpoolOptionsFlowHandler` class to `config_flow.py`
- All settings except Region can be modified after setup
- Use stable `entry_id`-based `unique_id` for UI-configured sensors (prevents duplicate sensors when changing settings)
- YAML configurations continue using legacy `unique_id` format
- Add options translations for all 10 supported languages (machine translated - corrections welcome)
- Update README documentation

Closes #102

## ⚠️ Important upgrade note for existing users

If you installed Nordpool via UI before this version:
- **Your existing sensor will continue to work normally** - no action required
- **If you use the new "Configure" button** to change any setting, your sensor's `unique_id` will change from the legacy format (`nordpool_kwh_fi_eur_3_10_025`) to the new stable format (`nordpool_<entry_id>`)
- Home Assistant will treat this as a new sensor entity
- You may need to update automations and dashboards to reference the new entity ID

**This is a one-time migration.** After using Configure once, all future setting changes will keep the same sensor identity.

**New installations** are not affected - they will use the stable `unique_id` from the start.